### PR TITLE
Add an api (Part 1 of challenge)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /public/storage
 /storage/*.key
 /vendor
+/.vscode
 .env
 .env.backup
 .phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ To interact with the local website that is running visit http://localhost:8000
 
 # Design Decisions
 - I went with a custom Dockerfile and docker-compose because I have built other Laravel apps in this way before and (considering the docker-compose approach was a bonus) I wanted to use an approach I'd be familiar with.
+- I'm going to generate a unique ID for each full URL. In order to avoid ID collisions, I'm going to append a unique number to the front of each URL before hashing. This will be a unique ID tracked in the database.
 
 ---
 
 # Future Improvements
 
 - I'm aware that Laravel has now come out with tools to auto-generate a docker-compose file. With more time, I'd do more digging into official Laravel build processes and see if it's just easier to use their process or if there are things about their process that I could use to improve my own.
+- I would implement a login process and implement some rate limiting based off of user id per day to prevent irresponsible use of the service and overload on resources.

--- a/app/Http/Controllers/TinyUrlController.php
+++ b/app/Http/Controllers/TinyUrlController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+// Models
+use App\TinyUrl;
+
+class TinyUrlController extends Controller
+{
+    // List the top 100 URLs 
+    // public function list() {
+
+    // }
+
+    // Create a new tiny URL
+    // public function create(Request $request) {
+
+    // }
+
+    // Hit the tiny URL
+        // Should increment hit count and redirect to full URL
+    // public function hit(Request $request) {
+
+    // }
+
+    // Delete a tiny URL by ID
+    // public function delete(Request $request) {
+
+    // }
+}

--- a/app/Http/Controllers/TinyUrlController.php
+++ b/app/Http/Controllers/TinyUrlController.php
@@ -3,30 +3,120 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+use Symfony\Component\HttpFoundation\Response;
 
 // Models
-use App\TinyUrl;
+use App\Models\TinyUrl;
 
 class TinyUrlController extends Controller
 {
-    // List the top 100 URLs 
-    // public function list() {
+    /**
+     * List the top 100 URLs 
+     * @return JSONResponse
+     */
+    public function list(Request $request) {
+        // Allow users to pick limit. Default to 100 entries
+        $limit = 100;
+        if ($request->query('limit') !== null) {
+            $limit = (int)$request->query('limit');
+        }
 
-    // }
+        // Fetch TinyUrls ordered by hit count
+        $tiny_urls = TinyUrl::orderBy('hits', 'desc')
+                                ->limit($limit)
+                                ->get();
+    
+        // Only map relevant fields for the response
+        $res = array_map(function ($tiny_url) {
+            return (object)[
+                'tiny_url' => config('app.url') . '/' . $tiny_url['id'],
+                'full_url' => $tiny_url['full_url'],
+                'hits' => $tiny_url['hits']
+            ];
+        }, $tiny_urls->toArray());
 
-    // Create a new tiny URL
-    // public function create(Request $request) {
+        return response()->json($res);
+    }
 
-    // }
+    /**
+     * Create a new tiny URL
+     * @return JSONResponse
+     */
+    public function create(Request $request) {
+        $validatedData = Validator::make($request->all(), [
+            'url' => 'required|url|max:512'
+        ]);
 
-    // Hit the tiny URL
-        // Should increment hit count and redirect to full URL
-    // public function hit(Request $request) {
+        if ($validatedData->fails()) {
+            return response()->json($validatedData->messages(), Response::HTTP_BAD_REQUEST);
+        }
 
-    // }
+        // Fetch last seed used in a hash
+        $last_seed = TinyUrl::max('seed');
 
-    // Delete a tiny URL by ID
+        // Create the ID
+        $id = $this->generateHash($request->url, ++$last_seed);
+
+        // Keep trying different seeds if an id collision is found
+        $collision_count = 0;
+        while (TinyUrl::where('id', $id)->exists()) {
+            $collision_count++;
+            $id = $this->generateHash($request->url, ++$last_seed);
+            if ($collision_count > 5) {
+                return response()->json([
+                    'id' => [
+                        'Failed to generate a tiny URL. Could not generate a unique ID'
+                    ]
+                ], Response::HTTP_INTERNAL_SERVER_ERROR);
+            }
+        }
+        
+        // Create a new TinyUrl
+        $tiny_url = TinyUrl::create([
+            'id' => $id,
+            'full_url' => $request->url
+        ]);
+
+        $tiny_url->save();
+
+        return response()->json([
+            'tiny_url' => config('app.url') . '/' . $id
+        ]);
+    }
+
+    /**
+     * Hit the tiny URL
+     * Should increment hit count and redirect to full URL
+     * @return RedirectResponse
+     */
+    public function hit(Request $request, $id) {
+        // Find the right tiny URL
+        $tiny_url = TinyUrl::where('id', $id)->firstOrFail();
+
+        // Update hit count
+        $tiny_url->update(['hits' => ++$tiny_url->hits]);
+        $tiny_url->save();
+
+        return redirect()->away($tiny_url->full_url);
+    }
+
+    /**
+     * Delete a tiny URL by ID
+     * @return Response
+     */
     // public function delete(Request $request) {
 
     // }
+
+    /**
+     * Generate an md5 hash, base64 encoded and return the first 7 characters
+     * @return string
+     */
+    private function generateHash($url, $seed) {
+        $key = $seed . $url;
+        $hash = md5($key);
+        $hash = base64_encode($hash);
+        return substr($hash, 0, 7);
+    }
 }

--- a/app/Models/TinyUrl.php
+++ b/app/Models/TinyUrl.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TinyUrl extends Model
+{
+    use HasFactory;
+
+    /**
+    *The table associated with the model
+    *
+    * @var string
+    */
+    protected $primaryKey = 'id';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'full_url', 'hits'
+    ];
+}

--- a/app/Models/TinyUrl.php
+++ b/app/Models/TinyUrl.php
@@ -9,12 +9,11 @@ class TinyUrl extends Model
 {
     use HasFactory;
 
-    /**
-    *The table associated with the model
-    *
-    * @var string
-    */
-    protected $primaryKey = 'id';
+    public $incrementing = false;
+    protected $keyType = 'string';
+    protected $casts = [
+        'id' => 'string'
+    ];
 
     /**
      * The attributes that are mass assignable.
@@ -22,6 +21,13 @@ class TinyUrl extends Model
      * @var array
      */
     protected $fillable = [
-        'full_url', 'hits'
+        'id', 'full_url', 'hits'
+    ];
+
+    /**
+     * The attributes that are not needed when model is fetched.
+     */
+    protected $hidden = [
+        'created_at', 'updated_at', 'seed'
     ];
 }

--- a/database/migrations/2021_05_23_001946_create_tiny_urls_table.php
+++ b/database/migrations/2021_05_23_001946_create_tiny_urls_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTinyUrlsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tiny_urls', function (Blueprint $table) {
+            $table->string('id', 7)->primary();
+            $table->string('full_url', 512);
+            $table->integer('hits')->default('0');
+            $table->increments('seed');
+            $table->timestamp('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('tiny_urls');
+    }
+}

--- a/database/migrations/2021_05_23_001946_create_tiny_urls_table.php
+++ b/database/migrations/2021_05_23_001946_create_tiny_urls_table.php
@@ -17,9 +17,9 @@ class CreateTinyUrlsTable extends Migration
             $table->string('id', 7)->primary();
             $table->string('full_url', 512);
             $table->integer('hits')->default('0');
-            $table->increments('seed');
-            $table->timestamp('created_at');
+            $table->timestamps();
         });
+        DB::statement('ALTER TABLE tiny_urls ADD seed INTEGER NOT NULL UNIQUE AUTO_INCREMENT;');
     }
 
     /**

--- a/docker-config/docker-entrypoint.sh
+++ b/docker-config/docker-entrypoint.sh
@@ -9,7 +9,7 @@ composer install
 cp .env.example .env
 NEWKEY=$(php artisan key:generate --show)
 sed -i "s|APP_KEY=|APP_KEY=$NEWKEY|" .env
-php artisan migrate
+php artisan migrate:fresh
 php artisan config:cache
 
 # Update to a viable version of node

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\TinyUrlController;
 
 /*
 |--------------------------------------------------------------------------
@@ -17,3 +18,6 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:api')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::get('/url', [TinyUrlController::class, 'list']);
+Route::post('/url', [TinyUrlController::class, 'create']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\TinyUrlController;
 
 /*
 |--------------------------------------------------------------------------
@@ -16,3 +17,5 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/{id}', [TinyUrlController::class, 'hit']);


### PR DESCRIPTION
- Ignoring vscode extension settings (used for local testing). 
- Updated README instructions, challenges faced, design decisions, and future improvements ideas based off the work done to add the tiny url API. 
- Added full controller methods to satisfy the functionality called out in the challenge: create a tiny url, list the top 100 tiny urls, and use a tiny url to redirect to it's full destination.
- Updated the TinyUrl model to type cast the id field properly and hide unneeded fields from model collections. 
- Updated the tiny_urls table migration to create the seed field as auto-incrementing but NOT a primary key. 
- Changed docker-entrypoint to just do a fresh database on every deploy (easier to avoid migration conflicts). 
- Added routes to handle the requested functionality from part 1 of the challenge.